### PR TITLE
Fix/hotfix auth provider

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "com2020-frontend",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "com2020-frontend",
-            "version": "0.4.0",
+            "version": "0.4.1",
             "dependencies": {
                 "react": "^19.2.3",
                 "react-dom": "^19.2.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com2020-frontend",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "description": "Frontend for the COM2020 Group Project",
     "type": "module",
     "scripts": {

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -8,7 +8,7 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 
 import App from "./App"; // Loads the SPA
-import { AuthProvider } from "./context/authContext"; // Authentication context
+import { AuthProvider } from "./context/AuthContext"; // Authentication context
 import "./styles/index.css"; // Loads TailwindCSS
 
 // Apply the app to the HTML


### PR DESCRIPTION
`main` function now imports correctly-named `AuthProvider.jsx`